### PR TITLE
feat: Add Antigravity support as a target agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ skillpack init
 ```yaml
 agents:
   - claude-code
+  - antigravity
   - cursor
 
 skills:
@@ -49,6 +50,7 @@ skillpack install
 # Target agents to install skills to
 agents:
   - claude-code
+  - antigravity
   - cursor
 
 # Skills to install (owner/repo format)
@@ -67,6 +69,16 @@ skills:
     skills:
       - specific-skill
 ```
+
+### Supported Agents
+
+| Agent | Local Skills Dir | Global Skills Dir |
+|-------|------------------|-------------------|
+| `claude-code` | `.claude/skills/` | `~/.claude/skills/` |
+| `antigravity` | `.agent/skills/` | `~/.gemini/antigravity/skills/` |
+| `cursor` | `.cursor/skills/` | `~/.cursor/skills/` |
+
+Skills are installed by the underlying `npx skills add` command from [skills.sh](https://skills.sh).
 
 ### Lockfile
 

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "ai",
     "claude",
     "cursor",
+    "antigravity",
     "package-manager",
     "cli"
   ],

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -42,6 +42,7 @@ function getDefaultTemplate(): string {
 # Target agents to install skills to
 agents:
   - claude-code
+  - antigravity
   # - cursor
 
 # Skills to install (owner/repo format)

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,5 +1,9 @@
 import { z } from "zod";
 
+// Supported agents for skill installation
+export const SUPPORTED_AGENTS = ['claude-code', 'cursor', 'antigravity'] as const;
+export type SupportedAgent = typeof SUPPORTED_AGENTS[number];
+
 // Schema for individual skill entry in config
 // Can be:
 // - "all" (install all skills from repo)

--- a/templates/skillpack.yaml
+++ b/templates/skillpack.yaml
@@ -4,6 +4,7 @@
 # Target agents to install skills to
 agents:
   - claude-code
+  - antigravity
   # - cursor
 
 # Skills to install (owner/repo format)

--- a/tests/agents.test.ts
+++ b/tests/agents.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { SUPPORTED_AGENTS } from '../src/lib/types.js';
+
+describe('Supported Agents', () => {
+  it('should include claude-code', () => {
+    expect(SUPPORTED_AGENTS).toContain('claude-code');
+  });
+
+  it('should include cursor', () => {
+    expect(SUPPORTED_AGENTS).toContain('cursor');
+  });
+
+  it('should include antigravity', () => {
+    expect(SUPPORTED_AGENTS).toContain('antigravity');
+  });
+
+  it('should have at least 3 agents supported', () => {
+    expect(SUPPORTED_AGENTS.length).toBeGreaterThanOrEqual(3);
+  });
+});


### PR DESCRIPTION
## Summary

This PR adds support for **Google Antigravity** as a target agent for skill installation.

> *"Never Outshine the Master"* — But I hope this small contribution helps illuminate the path forward 🌟

## Changes

- ✅ Updated `templates/skillpack.yaml` to include `antigravity` as a default agent
- ✅ Updated inline template in `src/commands/init.ts`
- ✅ Added `SUPPORTED_AGENTS` constant in `src/lib/types.ts` for better type safety
- ✅ Updated documentation with Antigravity-specific paths and examples in `README.md`
- ✅ Added `antigravity` keyword to `package.json`
- ✅ Added `tests/agents.test.ts` for supported agents validation

## Why

The underlying `npx skills add` CLI from [add-skill](https://github.com/vercel-labs/add-skill) already supports Antigravity with the following configuration:

```typescript
antigravity: {
  skillsDir: '.agent/skills',
  globalSkillsDir: '~/.gemini/antigravity/skills',
}
```

This change makes skillpack consistent with the broader agent skills ecosystem.

## Supported Agents Table (added to README)

| Agent | Local Skills Dir | Global Skills Dir |
|-------|------------------|-------------------|
| `claude-code` | `.claude/skills/` | `~/.claude/skills/` |
| `antigravity` | `.agent/skills/` | `~/.gemini/antigravity/skills/` |
| `cursor` | `.cursor/skills/` | `~/.cursor/skills/` |

## Testing

- [x] `npm run build` passes
- [x] `npm test` passes (23 tests)
- [x] `skillpack init` generates config with antigravity
- [x] `skillpack install --dry-run` shows correct agent flags (`-a antigravity`)